### PR TITLE
fix: preserve tiptap inline styles in admin editor

### DIFF
--- a/components/UiTiptapEditor.vue
+++ b/components/UiTiptapEditor.vue
@@ -132,7 +132,7 @@
     <!-- Editor -->
     <EditorContent
       :editor="editor"
-      class="w-full max-w-none rounded border border-gray-300 bg-white p-4 shadow overflow-auto"
+      class="tiptap w-full max-w-none rounded border border-gray-300 bg-white p-4 shadow overflow-auto"
       style="max-height: 800px; min-height: 300px"
     />
 
@@ -255,7 +255,7 @@ const editor = useEditor({
     StarterKit.configure({ bold: false }), // using CustomBold
     TextStyle,
     FontSize,
-    FontFamily.configure({ types: ['textStyle'] }),
+    FontFamily.configure({ types: ['textStyle', 'customBold'] }),
     Color.configure({ types: ['textStyle', 'customBold'] }),
     CustomBold,
     Underline,
@@ -283,7 +283,7 @@ watch(
     const normalized = convertInlineFontSizesToClasses(val || '<p></p>')
     const current = editor.value?.getHTML()
     if (editor.value && normalized !== current) {
-      editor.value.commands.setContent(normalized, false)
+      editor.value.commands.setContent(normalized, { emitUpdate: false })
     }
   },
 )
@@ -295,8 +295,7 @@ function onFontSizeChange(event: Event) {
   editor.value
     ?.chain()
     .focus()
-    .extendMarkRange('fontSize')
-    .unsetFontSize()
+    .extendMarkRange('textStyle')
     .setFontSize(raw)
     .run()
 }
@@ -359,68 +358,61 @@ async function insertImages(e: Event) {
 
 <style scoped>
 /* Editor base */
-:deep(.ProseMirror) { min-height: 300px; }
+ .tiptap :deep(.ProseMirror) { min-height: 300px; }
 
-:deep(.ProseMirror img) {
+ .tiptap :deep(.ProseMirror img) {
   max-width: 100%;
   height: auto;
   display: block;
   margin: 1rem 0;
 }
 
-/* Headings in editor */
-:deep(.ProseMirror h1),
-:deep(.ProseMirror h2),
-:deep(.ProseMirror h3) {
-  color: var(--cet-heading) !important;
-  font-family: var(--cet-heading-font) !important;
-}
-
 /* fs-* sizes */
-:deep(.ProseMirror .fs-12) { font-size: clamp(12px, 2.8vw, 12px) !important; }
-:deep(.ProseMirror .fs-14) { font-size: clamp(13px, 3.2vw, 14px) !important; }
-:deep(.ProseMirror .fs-16) { font-size: clamp(14px, 3.6vw, 16px) !important; }
-:deep(.ProseMirror .fs-18) { font-size: clamp(16px, 4.0vw, 18px) !important; }
-:deep(.ProseMirror .fs-24) { font-size: clamp(18px, 5.5vw, 24px) !important; }
-:deep(.ProseMirror .fs-32) { font-size: clamp(22px, 7.4vw, 32px) !important; }
-:deep(.ProseMirror .fs-48) { font-size: clamp(28px, 10.5vw, 48px) !important; }
+
+.tiptap :deep(.ProseMirror .fs-12) { font-size: clamp(12px, 2.8vw, 12px) !important; }
+.tiptap :deep(.ProseMirror .fs-14) { font-size: clamp(13px, 3.2vw, 14px) !important; }
+.tiptap :deep(.ProseMirror .fs-16) { font-size: clamp(14px, 3.6vw, 16px) !important; }
+.tiptap :deep(.ProseMirror .fs-18) { font-size: clamp(16px, 4.0vw, 18px) !important; }
+.tiptap :deep(.ProseMirror .fs-24) { font-size: clamp(18px, 5.5vw, 24px) !important; }
+.tiptap :deep(.ProseMirror .fs-32) { font-size: clamp(22px, 7.4vw, 32px) !important; }
+.tiptap :deep(.ProseMirror .fs-48) { font-size: clamp(28px, 10.5vw, 48px) !important; }
 
 /* Links pointer inside editor */
-:deep(.ProseMirror a) { cursor: pointer; }
+.tiptap :deep(.ProseMirror a) { cursor: pointer; }
 
 /* ✅ Table look while editing */
-:deep(.ProseMirror table){ width:100%; border-collapse:collapse; }
-:deep(.ProseMirror th),
-:deep(.ProseMirror td){
+.tiptap :deep(.ProseMirror table){ width:100%; border-collapse:collapse; }
+.tiptap :deep(.ProseMirror th),
+.tiptap :deep(.ProseMirror td){
   position: relative;           /* keep resizer + any overlays scoped to the cell */
   border:1px solid #d1d5db;
   padding:6px 8px;
   vertical-align:top;
 }
-:deep(.ProseMirror thead th){ background:#f3f4f6; font-weight:700; text-align:left; }
-:deep(.ProseMirror .column-resize-handle){
+.tiptap :deep(.ProseMirror thead th){ background:#f3f4f6; font-weight:700; text-align:left; }
+.tiptap :deep(.ProseMirror .column-resize-handle){
   position:absolute; right:-2px; top:0; bottom:0; width:3px; background:rgba(0,0,0,.15); pointer-events:none;
 }
 
 /* ❌ Remove the extra blue overlay for table cell selections */
-:deep(.ProseMirror .selectedCell:after){ content:none; }
+.tiptap :deep(.ProseMirror .selectedCell:after){ content:none; }
 
 /* 🔵 Make browser text selection less intense inside the editor */
-:deep(.ProseMirror ::selection){ background: rgba(160, 195, 255, .28); }
+.tiptap :deep(.ProseMirror ::selection){ background: rgba(160, 195, 255, .28); }
 
 
 /* --- Fix: don't tint entire cells when selecting text --- */
-:deep(.ProseMirror .selectedCell) {
+.tiptap :deep(.ProseMirror .selectedCell) {
   background: transparent !important;           /* no blue fill on cells */
 }
-:deep(.ProseMirror .selectedCell)::after {
+.tiptap :deep(.ProseMirror .selectedCell)::after {
   content: none !important;                      /* remove overlay pseudo element */
   display: none !important;
 }
 
 /* Optional: if you still want a hint when doing a REAL cell selection,
    use a thin outline instead of a full fill. Comment out if not wanted. */
-:deep(.ProseMirror .cell-selection .selectedCell) {
+.tiptap :deep(.ProseMirror .cell-selection .selectedCell) {
   box-shadow: inset 0 0 0 2px #60a5fa;          /* visible outline only */
 }
 

--- a/extensions/CustomBold.ts
+++ b/extensions/CustomBold.ts
@@ -11,6 +11,8 @@ declare module '@tiptap/core' {
 
 export const CustomBold = Mark.create({
   name: 'customBold',
+  // Allow other marks (color, font family, etc.) to mix with bold
+  excludes: '',
 
   addAttributes() {
     return {

--- a/extensions/FontSize.ts
+++ b/extensions/FontSize.ts
@@ -1,17 +1,16 @@
 // /extensions/FontSize.ts
-// Class-based Font Size mark for TipTap
-// - Writes class="fs-24" + data-fs="24px" (no inline styles)
-// - Allows coexistence with other marks (bold, color, etc.) via `excludes: ''`
-// - Parses legacy style="font-size: 24px" so old content still renders
-// - Exports a type guard to keep UI code strictly typed
+// Font size attribute tied to TipTap's textStyle mark.
+// - Stores size as class="fs-24" + data-fs="24px" for responsive CSS.
+// - Parses legacy inline styles and our data attributes/classes.
+// - Provides type-safe commands for setting/unsetting font size.
 
-import { Mark, mergeAttributes } from '@tiptap/core'
+import { Extension } from '@tiptap/core'
 
 /** Keep in sync with your toolbar options */
 export const FONT_SIZE_VALUES = ['12px', '14px', '16px', '18px', '24px', '32px', '48px'] as const
 export type FontSizeValue = typeof FONT_SIZE_VALUES[number]
 
-/** TS type guard for narrowing arbitrary strings */
+/** Type guard to narrow arbitrary strings */
 export function isFontSizeValue(s: string): s is FontSizeValue {
   return (FONT_SIZE_VALUES as readonly string[]).includes(s)
 }
@@ -27,74 +26,55 @@ declare module '@tiptap/core' {
   }
 }
 
-export const FontSize = Mark.create({
+const FontSize = Extension.create({
   name: 'fontSize',
-  group: 'inline',
-  inline: true,
 
-  // ✅ Important: don't exclude other marks; let font size mix with bold, color, link, etc.
-  excludes: '',
+  addGlobalAttributes() {
+    return [
+      {
+        types: ['textStyle'],
+        attributes: {
+          fontSize: {
+            default: null as FontSizeValue | null,
+            renderHTML: attrs => {
+              const size = attrs.fontSize as FontSizeValue | null
+              if (!size) return {}
+              const numeric = String(size).replace(/[^0-9]/g, '')
+              return {
+                class: `fs-${numeric}`,
+                'data-fs': size,
+              }
+            },
+            parseHTML: element => {
+              const ds = element.getAttribute('data-fs')
+              if (ds && isFontSizeValue(ds)) return ds
 
-  addAttributes() {
-    return {
-      size: {
-        default: null as FontSizeValue | null,
+              const cls = element.getAttribute('class') || ''
+              const m = cls.match(/\bfs-(12|14|16|18|24|32|48)\b/)
+              if (m) return `${m[1]}px` as FontSizeValue
 
-        // Render as class + data attribute (no inline style)
-        renderHTML: (attrs: { size?: FontSizeValue | null }) => {
-          const size = attrs.size ?? null
-          if (!size) return {}
-          const numeric = String(size).replace(/[^0-9]/g, '') // "24px" -> "24"
-          return {
-            class: `fs-${numeric}`,
-            'data-fs': size,
-          }
-        },
+              const styleVal = (element as HTMLElement).style.fontSize || ''
+              if (styleVal && isFontSizeValue(styleVal)) return styleVal
 
-        // Parse from data-fs, class, or legacy inline style="font-size: XXpx"
-        parseHTML: (el: HTMLElement) => {
-          const ds = el.getAttribute('data-fs')
-          if (ds && isFontSizeValue(ds)) return ds
-
-          const cls = el.getAttribute('class') || ''
-          const m = cls.match(/\bfs-(12|14|16|18|24|32|48)\b/)
-          if (m) return `${m[1]}px` as FontSizeValue
-
-          const styleVal = (el.style && el.style.fontSize) || ''
-          if (styleVal && isFontSizeValue(styleVal)) return styleVal
-
-          return null
+              return null
+            },
+          },
         },
       },
-    }
-  },
-
-  // Let TipTap discover this mark in raw HTML
-  parseHTML() {
-    return [
-      { tag: 'span[data-fs]' },
-      { tag: 'span[class*="fs-"]' },
-      { style: 'font-size' }, // legacy fallback
     ]
   },
 
-  // Render wrapper
-  renderHTML({ HTMLAttributes }) {
-    return ['span', mergeAttributes(HTMLAttributes), 0]
-  },
-
-  // Commands used by your toolbar
   addCommands() {
     return {
       setFontSize:
-        (size: FontSizeValue) =>
+        size =>
         ({ chain }) =>
-          chain().setMark(this.name, { size }).run(),
+          chain().setMark('textStyle', { fontSize: size }).run(),
 
       unsetFontSize:
         () =>
         ({ chain }) =>
-          chain().unsetMark(this.name).run(),
+          chain().setMark('textStyle', { fontSize: null }).removeEmptyTextStyle().run(),
     }
   },
 })

--- a/tests/tiptap-style-smoke.test.ts
+++ b/tests/tiptap-style-smoke.test.ts
@@ -1,0 +1,35 @@
+import { JSDOM } from 'jsdom'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import TextStyle from '@tiptap/extension-text-style'
+import Color from '@tiptap/extension-color'
+import FontFamily from '@tiptap/extension-font-family'
+import FontSize from '../extensions/FontSize'
+import { CustomBold } from '../extensions/CustomBold'
+import assert from 'node:assert'
+
+// jsdom setup
+const { window } = new JSDOM('<!doctype html><html><body></body></html>')
+// @ts-ignore
+global.window = window
+// @ts-ignore
+global.document = window.document
+
+const editor = new Editor({
+  extensions: [
+    StarterKit.configure({ bold: false }),
+    TextStyle,
+    FontSize,
+    FontFamily.configure({ types: ['textStyle', 'customBold'] }),
+    Color.configure({ types: ['textStyle', 'customBold'] }),
+    CustomBold,
+  ],
+})
+
+const html = `<p><span style="color: #ff0000; font-family: Georgia;" class="fs-24" data-fs="24px">Test</span></p>`
+editor.commands.setContent(html, { emitUpdate: false })
+const output = editor.getHTML()
+
+assert.ok(output.includes('color: #ff0000'))
+assert.ok(output.includes('font-family: Georgia'))
+assert.ok(output.includes('class="fs-24"'))


### PR DESCRIPTION
## Summary
- ensure custom bold mixes with other marks
- unify font-size mark with textStyle to keep color and font family
- scope editor styles with `.tiptap` class and load HTML without emitting updates
- add smoke test for retaining color, font family, and font size

## Testing
- `node tests/tiptap-style-smoke.test.ts` *(fails: command not found: node)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b1b66648325959fb1313dc2fa6e